### PR TITLE
Fix bug with reference link normalization.

### DIFF
--- a/lib/inlines.js
+++ b/lib/inlines.js
@@ -101,7 +101,7 @@ var normalizeReference = function(string) {
     return string
         .slice(1, string.length - 1)
         .trim()
-        .replace(/[ \t\r\n]+/, " ")
+        .replace(/[ \t\r\n]+/g, " ")
         .toLowerCase()
         .toUpperCase();
 };

--- a/test/regression.txt
+++ b/test/regression.txt
@@ -216,3 +216,14 @@ Issue cmark/#383 - emphasis parsing.
 <p>**<em><strong>Hello<em>world</em></strong></em></p>
 ````````````````````````````````
 
+Issue reported at
+https://talk.commonmark.org/t/link-label-collapse-all-internal-whitespace/3919/5
+
+```````````````````````````````` example
+[foo][one two
+  three]
+
+[one two three]: /url "title"
+.
+<p><a href="/url" title="title">foo</a></p>
+````````````````````````````````


### PR DESCRIPTION
We were only collapsing the first group of consecutive
whitespace, not following ones.

Reported at
<https://talk.commonmark.org/t/link-label-collapse-all-internal-whitespace/3919/6>.